### PR TITLE
Dev remove the light mode settings

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -53,16 +53,3 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
Currently the light mode settings prevent some words from being seen, so removed it tentatively (after discussion with @kavantan ), will leave it for work in the future for better user experience